### PR TITLE
fix(navbar): mobile burger drawer opens behind the page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -94,6 +94,18 @@ body {
   border-bottom: 1px solid var(--ap-border);
   box-shadow: none;
 }
+/* Mobile burger drawer fix: Docusaurus renders the slide-out nav
+   (.navbar-sidebar) and its backdrop as position:fixed CHILDREN of .navbar.
+   A non-none backdrop-filter makes .navbar the containing block for those
+   fixed descendants, so top/bottom:0 resolve against the ~60px navbar instead
+   of the viewport — the drawer collapses to a thin strip and its links become
+   unreachable behind the page. Dropping the filter while the drawer is open
+   restores the viewport as the containing block. The blur is moot here anyway:
+   the drawer + dark backdrop already cover the page. */
+.navbar.navbar-sidebar--show {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
 .navbar__link {
   position: relative;
 }


### PR DESCRIPTION
## Summary

On mobile, tapping the burger menu opened the slide-out nav **behind** the page content — the nav links were unreachable and only the ✕ (close) button worked. This PR fixes it with a 12-line, CSS-only change.

## Root cause

Not a z-index value problem — a CSS **containing-block** problem.

The glassmorphism header sets `backdrop-filter: blur(12px)` on `.navbar`. Docusaurus renders the mobile drawer (`.navbar-sidebar`) and its backdrop as `position: fixed` **children of `.navbar`**. Per the CSS spec, an element with a non-`none` `backdrop-filter` becomes the **containing block for its fixed-position descendants**. So the drawer's `top: 0; bottom: 0` resolved against the ~60px `.navbar` box instead of the viewport — collapsing the drawer to a ~59px strip and leaving its links stuck behind the page.

## Fix

```css
.navbar.navbar-sidebar--show {
  backdrop-filter: none;
  -webkit-backdrop-filter: none;
}
```

Disable the blur **only while the drawer is open**. This restores the viewport as the containing block. Desktop / closed-drawer glassmorphism is untouched, and the blur is visually moot while the drawer is open anyway — the drawer + dark backdrop already cover the page.

## Verification

Reproduced and verified in headless Chromium at a real 375×812 mobile viewport, before and after:

| | Drawer | Backdrop |
|---|---|---|
| **Before** | 311×**59** (clipped) | 375×**59** (clipped) |
| **After** | 311×**812** (full viewport) | 375×**812** (full viewport) |

- ✅ All 7 nav links pass an `elementFromPoint` hit-test (actually clickable)
- ✅ Clicking a nav link navigates
- ✅ Clicking the backdrop closes the drawer
- ✅ `npm run build` passes (with `onBrokenLinks: throw`)

Fixes kanban task `t_f23e171a`.