### PR TITLE
fix(search): add magnifying glass icon to mobile search input

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -124,10 +124,30 @@ body {
   border-radius: 2px;
 }
 .navbar__search-input {
-  background: var(--ap-surface-2);
+  background-color: var(--ap-surface-2);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23909296' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: 0.6rem center;
+  background-size: 1rem 1rem;
   border: 1px solid var(--ap-border-strong);
   border-radius: 8px;
   color: var(--ap-text);
+  padding-left: 2rem;
+}
+
+/* Mobile: magnifying glass icon always visible inside collapsed search box */
+@media (max-width: 768px) {
+  .navbar__search-input {
+    background-position: center center;
+    background-size: 1.15rem 1.15rem;
+  }
+
+  /* When search is expanded (focused), move icon back to the left */
+  .searchBarContainer_NW3z.focused_OWtg .navbar__search-input {
+    background-position: 0.6rem center;
+    background-size: 1rem 1rem;
+    padding-left: 2rem;
+  }
 }
 
 /* ---- Footer ------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

On mobile, the collapsed search box had no visible magnifying glass icon — users couldn't tell it was a search field. This PR adds the icon back as a CSS-only change (1 file, +21/−1).

## Root cause

The custom CSS for `.navbar__search-input` used the `background` shorthand (`background: var(--ap-surface-2)`), which **reset** Docusaurus' built-in magnifying glass `background-image`. The `background` shorthand overwrites all background sub-properties including `background-image`, so the icon was stripped on all viewports — but especially noticeable on mobile where the collapsed box gave zero visual hint that it was search.

## Fix

1. Switched from `background` shorthand to individual properties: `background-color` + `background-image` (inline SVG magnifying glass at `#909296`) + `background-repeat`/`background-position`/`background-size`
2. Added `padding-left: 2rem` so the icon has breathing room and typed text doesn't overlap it
3. Added a `@media (max-width: 768px)` block:
   - **Collapsed:** icon centered, slightly larger (1.15rem) — gives a clear visual target
   - **Expanded (focused):** icon moves back to left edge (0.6rem), same size as desktop — consistent with expanded desktop behavior

## Code change

```css
/* Before */
.navbar__search-input {
  background: var(--ap-surface-2);       /* strips all sub-properties */
  ...
}

/* After */
.navbar__search-input {
  background-color: var(--ap-surface-2);
  background-image: url("data:image/svg+xml,...");  /* inline SVG icon */
  background-repeat: no-repeat;
  background-position: 0.6rem center;
  background-size: 1rem 1rem;
  padding-left: 2rem;
  ...
}

@media (max-width: 768px) {
  .navbar__search-input {
    background-position: center center;
    background-size: 1.15rem 1.15rem;
  }
  .searchBarContainer_NW3z.focused_OWtg .navbar__search-input {
    background-position: 0.6rem center;
    background-size: 1rem 1rem;
    padding-left: 2rem;
  }
}
```

## Verification

- `npm run build` passes cleanly (with `onBrokenLinks: throw`)
- Icon visible on all viewports: left-aligned on desktop, centered on mobile when collapsed, left-aligned on mobile when expanded
- No JS changes, no component swizzle — pure CSS, scoped to the search input

Fixes kanban task `t_495634fc`.