### PR TITLE
fix(tutorials): add missing 03 - prefix to XML tutorial title

### DIFF
--- a/docs/tutorials/Command to API/03-xml-out-to-api.mdx
+++ b/docs/tutorials/Command to API/03-xml-out-to-api.mdx
@@ -3,7 +3,7 @@ sidebar_position: 1
 slug: /tutorial/xml-output-to-api
 ---
 
-# XML output to API
+# 03 - XML output to API
 
 If your script or command outputs XML data, you can simply set the parse option to `xml` to convert it instantly into an API.
 


### PR DESCRIPTION
## Summary
Adds the missing `03 -` numbering prefix to the Command to API XML tutorial H1 so it matches the rest of the section.

## Symptom
Tutorials listing showed:
- `02 - CSV output to API`
- `XML output to API` (missing prefix)

## Root cause
`docs/tutorials/Command to API/03-xml-out-to-api.mdx` H1 was `# XML output to API` while sibling pages use `# NN - ...`.

## Fix
- Change H1 to `# 03 - XML output to API`

## Verification
- Diff is a 1-line title change in the single affected MDX file
- Other Command to API titles already use the `NN -` convention (`00`–`02`, `04`–`05`)

## Test plan
- [ ] After merge/deploy, open Tutorials → Command to API sidebar and confirm `03 - XML output to API`
- [ ] Spot-check remaining Command to API entries still show their prefixes

Kanban: t_e0302f22