### PR TITLE
docs: GTM homepage hero, intro rewrite, 15-minute onboarding tracks

### DIFF
--- a/docs/documentation/fifteen-minutes.mdx
+++ b/docs/documentation/fifteen-minutes.mdx
@@ -1,0 +1,155 @@
+---
+sidebar_position: 2
+displayed_sidebar: documentationSidebar
+slug: /start/fifteen-minutes
+title: 15-minute onboarding tracks
+sidebar_label: 15-minute tracks
+description: Three guided paths to a running Air Pipe surface in about fifteen minutes — MCP Postgres, REST API, or Stripe webhooks.
+---
+
+import Cards from "../../src/components/mdx-comps/Cards";
+import { MDXProvider } from "@mdx-js/react";
+import {
+  IconDatabase,
+  IconApi,
+  IconWebhook,
+} from "@tabler/icons-react";
+
+# 15-minute onboarding tracks
+
+Ship something real in about fifteen minutes. Each track uses a marketplace pack, ends in a callable surface, and keeps **OpenAPI / metrics / tracing** available so you can see what ran.
+
+**Prereqs (all tracks):** a free [Air Pipe account](https://app.airpipe.io/register). Managed cloud is enough; self-host is optional ([Install](/docs/install)).
+
+export const tracks = [
+  {
+    title: "Track A — MCP + Postgres",
+    to: "#track-a--mcp--postgres",
+    desc: "Expose Postgres as MCP tools an AI client can call",
+    icon: <IconDatabase color="#4dabf7" />,
+  },
+  {
+    title: "Track B — REST API",
+    to: "#track-b--rest-api-crud",
+    desc: "CRUD API over Postgres with optional JWT",
+    icon: <IconApi color="#4dabf7" />,
+  },
+  {
+    title: "Track C — Webhook / Stripe",
+    to: "#track-c--webhook--stripe",
+    desc: "Verify Stripe webhooks, store events, notify Slack",
+    icon: <IconWebhook color="#4dabf7" />,
+  },
+];
+export const col = "col--4";
+
+<MDXProvider components={Cards}>
+
+<Cards cards={tracks} col={col} />
+
+</MDXProvider>
+
+---
+
+## Track A — MCP + Postgres
+
+**Goal:** AI clients (Claude Desktop, Claude Code, Cursor, any MCP client) call your Postgres data as tools — with a real auth story.
+
+**Pack:** [MCP Postgres Starter](/docs/examples/marketplace/mcp-postgres-starter)  
+**Install in app:** [app.airpipe.io/marketplace?pack=mcp-postgres-starter](https://app.airpipe.io/marketplace?pack=mcp-postgres-starter)
+
+### Steps (~15 min)
+
+1. **Create / open an org** at [app.airpipe.io](https://app.airpipe.io) and install the pack into an environment.
+2. **Attach Postgres** — managed DB or your own connection string in the pack globals / secrets.
+3. **Seed** — call the pack’s seed endpoint (see pack page) so demo tenants + tasks exist.
+4. **Pick a tier**
+   - *Solo:* one shared token → `tasks-solo.yml` tools
+   - *Multi-tenant:* per-user tokens with `tenant_id` → `tasks.yml` + `auth.yml` (or OIDC via `auth-oidc.yml`)
+5. **Point an MCP client** at your Air Pipe MCP endpoint with the bearer token (pack README has the client snippet).
+6. **Call a tool** — e.g. `list_tasks` / `create_task` — and confirm rows in Postgres.
+
+### See it
+
+- MCP surface: [MCP tools](/docs/configuration/mcp-tools) — same auth path as HTTP
+- Optional: enable `docs: true` / `expose_metrics: true` on the config for OpenAPI + Prometheus
+
+### Next
+
+- Harden JWT / OIDC claims
+- Scope queries tighter per tenant
+- Add more interfaces as tools
+
+---
+
+## Track B — REST API (CRUD)
+
+**Goal:** Production-shaped CRUD over Postgres (users, posts, comments) you can curl immediately.
+
+**Pack:** [REST API Starter](/docs/examples/marketplace/rest-api-starter)  
+**Install in app:** [app.airpipe.io/marketplace?pack=rest-api-starter](https://app.airpipe.io/marketplace?pack=rest-api-starter)
+
+### Steps (~15 min)
+
+1. **Install the pack** into an environment.
+2. **Connect Postgres** and run **seed** so tables + sample data load.
+3. **Hit list endpoints** — e.g. `GET /api/users`, `GET /api/posts` (exact paths on the pack page).
+4. **Create a resource** with `POST` + JSON body; confirm with `GET` by id.
+5. **Optional JWT** — enable the pack’s `auth.yml` pattern when you want protected routes.
+6. **Turn on docs** — set `docs: true` and open the generated Swagger UI (`/documentation` self-hosted, or the managed docs route).
+
+### See it
+
+- [OpenAPI docs](/docs/features/openapi)
+- [Prometheus metrics](/docs/configuration/metrics)
+- [OpenTelemetry tracing](/docs/otel-tracing) on the self-hosted binary
+
+### Next
+
+- [Beginner tutorial](/docs/tutorial/setup) for hand-written YAML depth
+- [JWT verification starter](/docs/examples/marketplace/jwt-verification-starter)
+- Multi-tenant SaaS pack if you need org scoping
+
+---
+
+## Track C — Webhook / Stripe
+
+**Goal:** One endpoint that verifies Stripe signatures, stores events idempotently in Postgres, and notifies Slack.
+
+**Pack:** [Stripe Webhooks → DB → Slack](/docs/examples/marketplace/stripe-webhooks-db-slack)  
+**Install in app:** [app.airpipe.io/marketplace?pack=stripe-webhooks-db-slack](https://app.airpipe.io/marketplace?pack=stripe-webhooks-db-slack)
+
+### Steps (~15 min)
+
+1. **Install the pack** and attach Postgres (+ Slack webhook URL as a secret).
+2. **Set the Stripe webhook signing secret** from the Stripe Dashboard (or Stripe CLI).
+3. **Expose the endpoint** — managed public URL, or tunnel to self-host.
+4. **Send a test event** with Stripe CLI (`stripe trigger payment_intent.succeeded`) or Dashboard “Send test webhook”.
+5. **Confirm** — row in the events table + Slack message; replay the same event and confirm idempotency (no duplicate side effects).
+6. **Inspect** — logs/traces for the verify → store → notify action chain.
+
+### See it
+
+- Signature pattern explained on the pack page (HMAC over `{timestamp}.{raw_body}`)
+- [Durable state](/docs/configuration/state) patterns if you extend with cursors/dedupe sets
+- [Observability showcase](/docs/examples/marketplace/observability-showcase) for a metrics/tracing-heavy pack
+
+### Next
+
+- Map more Stripe event types to domain actions
+- Fan-out to email/SMS packs
+- Add access control on non-webhook admin routes
+
+---
+
+## After any track
+
+| Want… | Go here |
+|---|---|
+| Hand-written config fundamentals | [Start Here tutorial](/docs/tutorial/setup) |
+| Feature depth (MCP, OpenAPI, metrics, state…) | [Features](/docs/features/build-with-ai) |
+| Schema + field reference | [Configuration](/docs/configuration) |
+| More packs | [Marketplace browser](/marketplace) |
+| Self-host binary / container | [Install](/docs/install) |
+
+Questions or a pack that should be a fourth track? Open an issue or PR on [airpipe-docs](https://github.com/AirPipeIO/airpipe-docs).

--- a/docs/documentation/intro-tutorials.mdx
+++ b/docs/documentation/intro-tutorials.mdx
@@ -6,44 +6,69 @@ slug: /
 
 import Cards from "../../src/components/mdx-comps/Cards";
 import { MDXProvider } from "@mdx-js/react";
-import { IconClick, IconFiles, IconDownload } from "@tabler/icons-react";
+import {
+  IconClick,
+  IconFiles,
+  IconDownload,
+  IconRocket,
+  IconPackages,
+} from "@tabler/icons-react";
 
 # Introduction
 
-Air Pipe is a high performance backend as a service enabling you to build APIs, integrations, workflows and more effortlessly with zero code.
+**Air Pipe** is a platform for shipping high-performance **APIs, workflows, integrations, and AI/MCP services** from a prompt, declarative YAML, or a marketplace pack.
 
-Run self hosted or on our global managed backend. See below to get started.
+Deploy on **managed cloud** or a **single self-hosted binary**. Every HTTP and MCP surface can ship with **OpenAPI docs, Prometheus metrics, and OpenTelemetry tracing** — observability by default, not a black box.
+
+## What you can build
+
+- REST/CRUD APIs over Postgres, MySQL, SQLite, MongoDB, and more
+- Webhook pipelines (Stripe, GitHub, custom) with durable state and retries
+- MCP tool servers so AI agents call your data safely
+- RAG chatbots, LLM gateways, scheduled jobs, multi-tenant backends
+
+Configs are real deployable services with schema validation — not throwaway LLM sketches.
+
+## How to start
+
+Pick the path that matches how you like to work:
 
 export const desc = [
   {
-    title: "Beginner Tutorial",
-    to: "/docs/tutorial/setup",
-    desc: "Build in minutes!",
-    icon: <IconClick color="#007bff" />,
+    title: "15-minute tracks",
+    to: "/docs/start/fifteen-minutes",
+    desc: "Three Peerlist-friendly paths: MCP Postgres, REST API, or Stripe webhooks",
+    icon: <IconRocket color="#4dabf7" />,
   },
-  // {
-  //   title: "Getting Started",
-  //   to: "/docs/getting-started",
-  //   desc: "Get up and running in minutes",
-  //   icon: <IconClick color="#007bff" />,
-  // },
+  {
+    title: "Beginner tutorial",
+    to: "/docs/tutorial/setup",
+    desc: "Hand-written YAML walkthrough — setup through workflows",
+    icon: <IconClick color="#4dabf7" />,
+  },
   {
     title: "Install",
     to: "/docs/install",
-    desc: "Installation methods and supported platforms",
-    icon: <IconDownload color="#007bff" />,
+    desc: "Managed cloud, binary, container, Linux, macOS, Windows",
+    icon: <IconDownload color="#4dabf7" />,
   },
   {
     title: "Configuration",
     to: "/docs/configuration",
-    desc: "Learn the all features and available functionality",
-    icon: <IconFiles color="#007bff" />,
+    desc: "Interfaces, actions, globals, interpolation, and schema reference",
+    icon: <IconFiles color="#4dabf7" />,
+  },
+  {
+    title: "Marketplace",
+    to: "/marketplace",
+    desc: "Fork a ready pack — REST, MCP, RAG, webhooks, SaaS starters",
+    icon: <IconPackages color="#4dabf7" />,
   },
   {
     title: "Examples",
     to: "/docs/examples",
-    desc: "Instant deploy and modify any available examples",
-    icon: <IconFiles color="#007bff" />,
+    desc: "Worked examples across databases, HTTP, AI, and marketplace packs",
+    icon: <IconFiles color="#4dabf7" />,
   },
 ];
 export const col = "col--6";
@@ -53,3 +78,15 @@ export const col = "col--6";
 <Cards cards={desc} col={col} />
 
 </MDXProvider>
+
+## Why teams pick Air Pipe
+
+1. **Ship fast** — prompt, YAML, or marketplace pack; go live in minutes.
+2. **See everything** — OpenAPI (`docs: true`), Prometheus (`expose_metrics: true`), OpenTelemetry on the binary.
+3. **AI-native both ways** — [Build with AI](/docs/features/build-with-ai) for config generation; [MCP tools](/docs/configuration/mcp-tools) to expose your APIs to agents.
+4. **Run anywhere** — [app.airpipe.io](https://app.airpipe.io/register) managed, or self-host with one binary — no lock-in story.
+5. **Real backend primitives** — databases, webhooks, durable state, scheduling, access control, flow control.
+
+## Not sure where to begin?
+
+Start with the [15-minute onboarding tracks](/docs/start/fifteen-minutes). Each track ends in something you can hit with curl, an MCP client, or Stripe CLI — and that you can inspect with OpenAPI and metrics.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,19 +4,11 @@ import Layout from "@theme/Layout";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
 import Heading from "@theme/Heading";
 import styles from "./index.module.css";
-import ReactRotatingText from "react-rotating-text";
 import Dots from "./dots";
 
-const ROTATING = [
-  "APIs",
-  "workflows",
-  "AI agents",
-  "MCP servers",
-  "RAG chatbots",
-  "integrations",
-  "backend services",
-];
-
+// Build cards point at real docs pack pages (sitemap-verified slugs).
+// Do not rewrite to /marketplace?pack= — that SPA query is softer for SEO
+// and skips onBrokenLinks for the underlying pack docs.
 const BUILD = [
   {
     title: "REST API over your database",
@@ -58,16 +50,19 @@ function HomepageHeader() {
       <Dots className={styles.dots} style={{ left: 0, top: 140 }} />
       <Dots className={styles.dots} style={{ right: 0, top: 60 }} />
       <div className="container">
+        {/*
+          Single static H1 for a11y + GTM lock. (Rotating fragment text is
+          decorative elsewhere on the brand site; screen readers need one
+          stable heading that matches the recommended positioning line.)
+        */}
         <Heading as="h1" className={styles.heroTitle}>
-          <span>Ship </span>
-          <ReactRotatingText items={ROTATING} />
-          <br />
-          you can <span className={styles.highlight}>actually see</span>.
+          Ship APIs, workflows, and AI agents you can{" "}
+          <span className={styles.highlight}>actually see</span>.
         </Heading>
         <p className={styles.heroSubtitle}>
-          Build from a prompt or by hand — and go live in seconds. Every endpoint
-          ships with tracing, metrics, and OpenAPI docs generated automatically.
-          No black boxes.
+          Build from a prompt, YAML, or a marketplace pack. Every HTTP and MCP
+          surface can ship with OpenAPI, Prometheus metrics, and OpenTelemetry
+          — managed cloud or a single self-hosted binary.
         </p>
         <div className={styles.buttons}>
           <Link
@@ -90,8 +85,9 @@ function HomepageHeader() {
           </Link>
         </div>
         <p className={styles.heroFootnote}>
-          Describe it in plain English, write the config by hand, or fork a
-          marketplace pack. No card required.
+          Prefer a guided path? Try the{" "}
+          <Link to="/docs/start/fifteen-minutes">15-minute onboarding tracks</Link>
+          . No card required.
         </p>
       </div>
     </header>
@@ -111,7 +107,7 @@ function BuildStrip() {
         <div className="row">
           {BUILD.map((b, i) => (
             <div className="col col--4" key={i} style={{ marginBottom: "1.5rem" }}>
-              <Link to={b.to.replace("/docs/examples/marketplace/", "/marketplace?pack=")} className={styles.buildCard}>
+              <Link to={b.to} className={styles.buildCard}>
                 <h3 className={styles.buildTitle}>{b.title}</h3>
                 <p className={styles.buildDesc}>{b.desc}</p>
               </Link>
@@ -136,7 +132,7 @@ function ClosingCTA() {
     <section className={styles.closing}>
       <div className="container">
         <Heading as="h2" className={styles.sectionTitle}>
-          Ship your first API in five minutes
+          Ship your first API in fifteen minutes
         </Heading>
         <p className={styles.sectionSubtitle}>
           No credit card required. Managed or self-hosted.
@@ -144,6 +140,12 @@ function ClosingCTA() {
         <div className={styles.buttons}>
           <Link
             className="button button--primary button--lg"
+            to="/docs/start/fifteen-minutes"
+          >
+            Pick a 15-minute track
+          </Link>
+          <Link
+            className="button button--secondary button--lg"
             to="https://app.airpipe.io/register"
           >
             Start building — free
@@ -158,7 +160,7 @@ export default function Home() {
   return (
     <Layout
       title="Air Pipe — Ship APIs, workflows & AI agents you can actually see"
-      description="Build APIs, workflows, MCP servers and integrations from a prompt or by hand. Every endpoint ships with tracing, metrics and OpenAPI docs automatically. Managed or self-hosted."
+      description="Build from a prompt, YAML, or a marketplace pack. Every HTTP and MCP surface can ship with OpenAPI, Prometheus metrics, and OpenTelemetry — managed cloud or a single self-hosted binary."
     >
       <HomepageHeader />
       <main>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -19,9 +19,6 @@
   color: #f1f3f5;
   margin-bottom: 1.25rem;
 }
-.heroTitle :global(.react-rotating-text-cursor) {
-  color: #4dabf7;
-}
 .highlight {
   color: #4dabf7;
 }


### PR DESCRIPTION
Align docs.airpipe.io with positioning brief (t_1170c7a4):

- Homepage: static a11y H1 + locked subhead (prompt/YAML/pack, OpenAPI/Prometheus/OTel, managed or single binary)
- Build grid links go to docs pack pages (not /marketplace?pack=)
- Introduction: replace BaaS/zero-code framing with observable declarative backend positioning + start cards
- Add /docs/start/fifteen-minutes hub (MCP Postgres, REST, Stripe)